### PR TITLE
Fix white borders around PWA icon on Android

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -9,17 +9,20 @@
         {
             "src": "images/icon-64.png",
             "sizes": "64x64",
-            "type": "image/png"
+            "type": "image/png",
+            "purpose": "maskable any"
         },
         {
             "src": "images/icon-128.png",
             "sizes": "128x128",
-            "type": "image/png"
+            "type": "image/png",
+            "purpose": "maskable any"
         },
         {
             "src": "images/icon-256.png",
             "sizes": "256x256",
-            "type": "image/png"
+            "type": "image/png",
+            "purpose": "maskable any"
         }
     ]
 }


### PR DESCRIPTION
By default, Android will attempt to fit the whole image inside whatever icon shape the UI is configured to use, but this results in a huge white borders around a tiny graphic. It's better to have it just crop off the corners resulting in an icon that actually looks like a star chart instead of a black square in a white circle. 